### PR TITLE
refactor: force underscores in target table names

### DIFF
--- a/src/main/java/com/citusdata/migration/datamodel/TableSchema.java
+++ b/src/main/java/com/citusdata/migration/datamodel/TableSchema.java
@@ -24,11 +24,11 @@ public class TableSchema {
 	private List<TableIndex> tableIndexes;
 
 	public TableSchema(String tableName) {
-		this(tableName, null);
+		this(tableName.replace("-","_"), null);
 	}
 
 	public TableSchema(String tableName, String schemaName) {
-		this.tableName = tableName;
+		this.tableName = tableName.replace("-","_");
 		this.schemaName = schemaName;
 		this.columns = new LinkedHashMap<>();
 		this.primaryKey = null;


### PR DESCRIPTION
Podyn replicates the table names as they are in Dynamo. Yet at the same
time postgres requires that table names with dashes are quoted.

This commit makes podyn replace the dashes with underscores so that the
table names can be used w/o quotation in pgsql.